### PR TITLE
Docker image entrypoint fix for zkv_conf_chain check

### DIFF
--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -275,6 +275,8 @@ unset PARA_NODE_KEY
 ####
 # Relaychain node's configuration
 ####
+ZKV_SPEC_FILE_URL="${ZKV_SPEC_FILE_URL:-}"
+
 if [ "${DEV_MODE:-false}" != "true" ]; then
   # Call the function for EVM_CONF_CHAIN
   validate_and_download "ZKV_CONF_CHAIN" "ZKV_SPEC_FILE_URL"


### PR DESCRIPTION
Missed default value needs to be set for ZKV_SPEC_FILE_URL in order for validate_and_download function to work as desired