### PR TITLE
Add try-runtime to the CI orchestrator

### DIFF
--- a/.github/actions/cmd-in-docker/action.yml
+++ b/.github/actions/cmd-in-docker/action.yml
@@ -46,7 +46,12 @@ inputs:
     type: string
     default: ''
   skip_wasm_build:
-    description: 'If enable disable the runtime wasm build (reduces build time)'
+    description: 'If enabled, disable the runtime wasm build (reduces build time)'
+    required: false
+    type: string
+    default: ''
+  try_runtime:
+    description: 'If not empty, download the binary with the given version'
     required: false
     type: string
     default: ''
@@ -89,6 +94,7 @@ runs:
         CARGO_BINARIES_INSTALL: ${{ inputs.cargo_binaries_install }}
         NODEJS_VERSION_INSTALL: ${{ inputs.nodejs_version_install }}
         SKIP_WASM_BUILD: ${{ inputs.skip_wasm_build }}
+        TRY_RUNTIME: ${{ inputs.try_runtime }}
         DOCKER_BUILD_DIR: /build
         DOCKER_CARGO_HOME: /tmp/.cargo
       run: |

--- a/.github/workflows/CI-cache-cleanup.yaml
+++ b/.github/workflows/CI-cache-cleanup.yaml
@@ -16,6 +16,7 @@ jobs:
           - lint-format
           - machete
           - build-runtime-benchmarks
+          - build-try-runtime
           - unit-test
     steps:
       - name: "Deleting '${{ matrix.cache_key }}' cache key"

--- a/.github/workflows/CI-cache-default-branch.yml
+++ b/.github/workflows/CI-cache-default-branch.yml
@@ -26,6 +26,12 @@ jobs:
     name: Cargo test bench job cache rebuild
     uses: ./.github/workflows/CI-test-bench.yml
 
+  try-runtime-job-cache:
+    name: Try runtime job cache rebuild
+    uses: ./.github/workflows/CI-try-runtime.yml
+    with:
+      execute-try-runtime: 'no'
+
   lint-format-job-cache:
     name: Lint and format job cache rebuild
     uses: ./.github/workflows/CI-lint-format.yml

--- a/.github/workflows/CI-docker-build-publish.yml
+++ b/.github/workflows/CI-docker-build-publish.yml
@@ -69,11 +69,19 @@ jobs:
           source "${GITHUB_WORKSPACE}/ci/setup_env.sh"
           "${GITHUB_WORKSPACE}/ci/publish-docker-image.sh" --image-artifact ${{ needs.build-docker.outputs.artifact_name }}
 
-      - name: Upload runtime artifacts
+      - name: Upload Volta runtime artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: "vflow_runtime.compact.compressed.wasm"
-          path: ./vflow_runtime.compact.compressed.wasm
+          name: "vflow_volta_runtime.compact.compressed.wasm"
+          path: ./vflow_volta_runtime.compact.compressed.wasm
+          retention-days: 7
+          overwrite: true
+
+      - name: Upload Mainnet runtime artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: "vflow_mainnet_runtime.compact.compressed.wasm"
+          path: ./vflow_mainnet_runtime.compact.compressed.wasm
           retention-days: 7
           overwrite: true
 

--- a/.github/workflows/CI-orchestrator.yml
+++ b/.github/workflows/CI-orchestrator.yml
@@ -24,7 +24,12 @@ jobs:
     name: Cargo test bench job
     needs: [check-lockfile-job]
     uses: ./.github/workflows/CI-test-bench.yml
-    
+
+  try-runtime-job:
+    name: Try runtime job
+    needs: [check-lockfile-job]
+    uses: ./.github/workflows/CI-try-runtime.yml
+
   lint-format-job:
     name: Lint and format job
     needs: [check-lockfile-job]
@@ -54,6 +59,7 @@ jobs:
         build-job,
         test-job,
         test-bench-job,
+        try-runtime-job,
         lint-format-job,
         audit-job,
         feature-propagation-job,
@@ -99,6 +105,7 @@ jobs:
                 [ "${{ needs.build-job.result }}" != "success" ] ||
                 [ "${{ needs.test-job.result }}" != "success" ] ||
                 [ "${{ needs.test-bench-job.result }}" != "success" ] ||
+                [ "${{ needs.try-runtime-job.result }}" != "success" ] ||
                 [ "${{ needs.lint-format-job.result }}" != "success" ] ||
                 [ "${{ needs.feature-propagation-job.result }}" != "success" ] ||
                 [ "${{ needs.audit-job.result }}" != "success" ] ||

--- a/.github/workflows/CI-try-runtime.yml
+++ b/.github/workflows/CI-try-runtime.yml
@@ -1,0 +1,69 @@
+name: Try runtime
+
+run-name: "Workflow CI/CD Steps: execute try-runtime"
+
+on:
+  workflow_call:
+    inputs:
+      execute-try-runtime:
+        description: 'Whether to execute try-runtime step or not'
+        required: false
+        type: string
+        default: 'yes'
+      try-runtime-version:
+        description: 'What version of the try-runtime tool to use'
+        required: false
+        type: string
+        default: 'v0.8.0'
+  workflow_dispatch:
+    inputs:
+      execute-try-runtime:
+        description: 'Whether to execute try-runtime step or not'
+        required: false
+        type: string
+        default: 'yes'
+      try-runtime-version:
+        description: 'What version of the try-runtime tool to use'
+        required: false
+        type: string
+        default: 'v0.8.0'
+
+jobs:
+  try-runtime:
+    runs-on: warp-ubuntu-latest-x64-8x
+    name: Try runtime
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Runtimes build
+        uses: ./.github/actions/cmd-in-docker
+        with:
+          command: "cargo build -p vflow-mainnet-runtime -p vflow-volta-runtime --release --features try-runtime"
+          use_cache: 'yes'
+          cache_key: 'build-try-runtime'
+          lld_install: 'yes'
+
+      - name: Execute try-runtime Volta
+        if: ${{ inputs.execute-try-runtime == 'yes' }}
+        uses: ./.github/actions/cmd-in-docker
+        with:
+          command: >-
+            try-runtime --runtime /build/target/release/wbuild/vflow-volta-runtime/vflow_volta_runtime.compact.compressed.wasm \
+              on-runtime-upgrade \
+              --blocktime 6 --disable-mbm-checks --disable-spec-version-check live \
+              --uri wss://vflow-volta-rpc.zkverify.io/
+          try_runtime: ${{ inputs.try-runtime-version }}
+          use_cache: 'no'
+
+      - name: Execute try-runtime Mainnet
+        if: ${{ inputs.execute-try-runtime == 'yes' }}
+        uses: ./.github/actions/cmd-in-docker
+        with:
+          command: >-
+            try-runtime --runtime /build/target/release/wbuild/vflow-mainnet-runtime/vflow_mainnet_runtime.compact.compressed.wasm \
+              on-runtime-upgrade \
+              --blocktime 6 --disable-mbm-checks --disable-spec-version-check live \
+              --uri wss://vflow-rpc.zkverify.io/
+          try_runtime: ${{ inputs.try-runtime-version }}
+          use_cache: 'no'

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - "CMAKE_INSTALL=${CMAKE_INSTALL:-}"
       - "LLD_INSTALL=${LLD_INSTALL:-}"
       - "SKIP_WASM_BUILD=${SKIP_WASM_BUILD:-}"
+      - "TRY_RUNTIME=${TRY_RUNTIME:-}"
       - "LOCAL_USER_ID=${USER_ID:-}"
       - "LOCAL_GRP_ID=${GRP_ID:-}"
     entrypoint: ${DOCKER_BUILD_DIR}/ci/entrypoint.sh

--- a/ci/entrypoint.sh
+++ b/ci/entrypoint.sh
@@ -12,6 +12,7 @@ NODEJS_VERSION_INSTALL="${NODEJS_VERSION_INSTALL:-}"
 CMAKE_INSTALL="${CMAKE_INSTALL:-}"
 LLD_INSTALL="${LLD_INSTALL:-}"
 SKIP_WASM_BUILD="${SKIP_WASM_BUILD:-}"
+TRY_RUNTIME="${TRY_RUNTIME:-}"
 TARGET_DIR="${DOCKER_BUILD_DIR}/target"
 
 fn_die() {
@@ -116,6 +117,15 @@ if [ -n "${SKIP_WASM_BUILD}" ]; then
 else
   echo -e "\n=== WASM BUILD ENABLED ===\n"
   unset SKIP_WASM_BUILD
+fi
+
+if [ -n "${TRY_RUNTIME}" ]; then
+  TRY_RUNTIME_BIN="/usr/local/bin/try-runtime"
+  echo -e "\n=== TRY RUNTIME: version ${TRY_RUNTIME} to ${TRY_RUNTIME_BIN} ===\n"
+
+  curl -sL https://github.com/paritytech/try-runtime-cli/releases/download/${TRY_RUNTIME}/try-runtime-x86_64-unknown-linux-musl \
+    -o ${TRY_RUNTIME_BIN} && \
+    chmod +x ${TRY_RUNTIME_BIN}
 fi
 
 # Run


### PR DESCRIPTION
Integrate a `try-runtime` step in the Orchestrator workflow.

Also fix the runtime artifact names after renaming.